### PR TITLE
Removal of master and slave phrasing

### DIFF
--- a/dbcount/app01/urls.py
+++ b/dbcount/app01/urls.py
@@ -30,6 +30,6 @@ urlpatterns = [
     url(r'^tableinfo/$',views.tableinfo,name='tableinfo'),
     url(r'^tablecount/$',views.tablecount,name='tablecount'),
     url(r'^msinfo/$',views.msinfo,name='msinfo'),
-    url(r'^promoteslave/$',views.promoteslave,name='.promoteslave'),
+    url(r'^promotesubordinate/$',views.promotesubordinate,name='.promotesubordinate'),
 	url(r'^$',views.acc_login,name="dashboard"),
 ]

--- a/dbcount/app01/views.py
+++ b/dbcount/app01/views.py
@@ -223,11 +223,11 @@ def tablecount(request,*args,**kwargs):
 @outer
 def msinfo(request,*args,**kwargs):
     ret = {}
-    ret['data']='Master Slave Info Html Testing'
+    ret['data']='Main Subordinate Info Html Testing'
     return render(request,'app01/msinfo.html',ret)
 
 @outer
-def promoteslave(request,*args,**kwargs):
+def promotesubordinate(request,*args,**kwargs):
     ret = {}
-    ret['data']='Promote Slave  Html Testing'
-    return render(request,'app01/promoteslave.html',ret)
+    ret['data']='Promote Subordinate  Html Testing'
+    return render(request,'app01/promotesubordinate.html',ret)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.